### PR TITLE
test: Get e2e tests passing locally

### DIFF
--- a/kurtosis/src/services/blutgang/launcher.star
+++ b/kurtosis/src/services/blutgang/launcher.star
@@ -14,9 +14,9 @@ BLUTGANG_CONFIG_MOUNT_DIRPATH_ON_SERVICE = "/config"
 IMAGE_NAME = "makemake1337/blutgang:latest"
 
 # The min/max CPU/memory that blutgang can use
-MIN_CPU = 1000
+MIN_CPU = 0
 MAX_CPU = 8000
-MIN_MEMORY = 1024
+MIN_MEMORY = 0
 MAX_MEMORY = 8096
 
 USED_PORTS = {

--- a/kurtosis/src/services/blutgang/launcher.star
+++ b/kurtosis/src/services/blutgang/launcher.star
@@ -16,7 +16,7 @@ IMAGE_NAME = "makemake1337/blutgang:latest"
 # The min/max CPU/memory that blutgang can use
 MIN_CPU = 0
 MAX_CPU = 8000
-MIN_MEMORY = 1024
+MIN_MEMORY = 0
 MAX_MEMORY = 8096
 
 USED_PORTS = {

--- a/kurtosis/src/services/blutgang/launcher.star
+++ b/kurtosis/src/services/blutgang/launcher.star
@@ -16,7 +16,7 @@ IMAGE_NAME = "makemake1337/blutgang:latest"
 # The min/max CPU/memory that blutgang can use
 MIN_CPU = 0
 MAX_CPU = 8000
-MIN_MEMORY = 0
+MIN_MEMORY = 1024
 MAX_MEMORY = 8096
 
 USED_PORTS = {

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -182,27 +182,27 @@ func defaultValidators() NodeSet {
 		Nodes: []Node{
 			{
 				ElType:   "nethermind",
-				Replicas: 1,
+				Replicas: 0,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "geth",
-				Replicas: 2, //nolint:mnd // bet.
+				Replicas: 1, //nolint:mnd // bet.
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "reth",
-				Replicas: 1,
+				Replicas: 4,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "erigon",
-				Replicas: 1,
+				Replicas: 0,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "besu",
-				Replicas: 1,
+				Replicas: 0,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 		},
@@ -215,12 +215,12 @@ func defaultFullNodes() NodeSet {
 		Nodes: []Node{
 			{
 				ElType:   "nethermind",
-				Replicas: 1,
+				Replicas: 0,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "reth",
-				Replicas: 1,
+				Replicas: 2,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
@@ -230,12 +230,12 @@ func defaultFullNodes() NodeSet {
 			},
 			{
 				ElType:   "erigon",
-				Replicas: 1,
+				Replicas: 0,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "besu",
-				Replicas: 1,
+				Replicas: 0,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 		},
@@ -247,7 +247,7 @@ func defaultSeedNodes() NodeSet {
 		Type: "seed",
 		Nodes: []Node{
 			{
-				ElType:   "geth",
+				ElType:   "reth",
 				Replicas: 1,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
@@ -266,8 +266,8 @@ func defaultExecutionSettings() ExecutionSettings {
 	return ExecutionSettings{
 		Specs: NodeSpecs{
 			MinCPU:    0,
-			MaxCPU:    0,
-			MinMemory: 1024, //nolint:mnd // 1 GB
+			MaxCPU:    2000,
+			MinMemory: 0,    //nolint:mnd // 1 GB
 			MaxMemory: 2048, //nolint:mnd // 2 GB
 		},
 		Images: map[string]string{

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -266,8 +266,8 @@ func defaultExecutionSettings() ExecutionSettings {
 	return ExecutionSettings{
 		Specs: NodeSpecs{
 			MinCPU:    0,
-			MaxCPU:    2000,
-			MinMemory: 0,    //nolint:mnd // 1 GB
+			MaxCPU:    0,
+			MinMemory: 1024, //nolint:mnd // 1 GB
 			MaxMemory: 2048, //nolint:mnd // 2 GB
 		},
 		Images: map[string]string{

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -187,12 +187,12 @@ func defaultValidators() NodeSet {
 			},
 			{
 				ElType:   "geth",
-				Replicas: 1, //nolint:mnd // bet.
+				Replicas: 1,
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
 				ElType:   "reth",
-				Replicas: 4,
+				Replicas: 4, //nolint:mnd // bet.
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{
@@ -220,7 +220,7 @@ func defaultFullNodes() NodeSet {
 			},
 			{
 				ElType:   "reth",
-				Replicas: 2,
+				Replicas: 2, //nolint:mnd // bet.
 				KZGImpl:  "crate-crypto/go-kzg-4844",
 			},
 			{

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -313,9 +313,8 @@ func defaultEthJSONRPCEndpoints() []EthJSONRPCEndpoint {
 			Type: "blutgang",
 			Clients: []string{
 				// "el-full-nethermind-0",
-				// "el-full-reth-0",
-				"el-full-geth-2",
-				// "el-full-erigon-3",
+				"el-full-reth-0",
+				// "el-full-geth-2",
 				// "el-full-erigon-3",
 				// Besu causing flakey tests.
 				// "el-full-besu-4",

--- a/testing/e2e/config/config.go
+++ b/testing/e2e/config/config.go
@@ -267,7 +267,7 @@ func defaultExecutionSettings() ExecutionSettings {
 		Specs: NodeSpecs{
 			MinCPU:    0,
 			MaxCPU:    0,
-			MinMemory: 1024, //nolint:mnd // 1 GB
+			MinMemory: 0,
 			MaxMemory: 2048, //nolint:mnd // 2 GB
 		},
 		Images: map[string]string{


### PR DESCRIPTION
# What

- Reduces `MIN_CPU` for blutgang from `1000` to `0` (this solves the cpu allocation issue)
- Changes number of validator and full nodes for each execution client to match the numbers in CI
- Uses `reth` instead of `geth` for JSON RPC

# Testing

`make test-e2e`: Passes
